### PR TITLE
Adding option to use a template as check script source

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,59 +1,58 @@
----
 dist: xenial
 language: ruby
 cache: bundler
 before_install:
-  - bundle -v
-  - rm -f Gemfile.lock
-  - gem update --system $RUBYGEMS_VERSION
-  - gem --version
-  - bundle -v
+- bundle -v
+- rm -f Gemfile.lock
+- gem update --system $RUBYGEMS_VERSION
+- gem --version
+- bundle -v
+- echo "$DOCKER_PASSWORD" | docker login -u "$DOCKER_USERNAME" --password-stdin
 script:
-  - 'bundle exec rake $CHECK'
-bundler_args: --without system_tests
+- bundle exec rake $CHECK
+bundler_args: "--without system_tests"
 rvm:
-  - 2.5.3
+- 2.5.3
 stages:
-  - static
-  - spec
-  - acceptance
-  -
-    if: tag =~ ^v\d
-    name: deploy
+- static
+- spec
+- acceptance
+- if: tag =~ ^v\d
+  name: deploy
 matrix:
   fast_finish: true
   include:
-    -
-      env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file rubocop syntax lint metadata_lint"
-      stage: static
-    -
-      env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
-      rvm: 2.4.5
-      stage: spec
-    -
-      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
-      rvm: 2.5.3
-      stage: spec
-    -
-      env: DEPLOY_TO_FORGE=yes
-      stage: deploy
-    -
-      env: PUPPET_GEM_VERSION="~> 6.0" CHECK=integration_test
-      rvm: 2.5.3
-      script: travis_wait 40 bundle exec rake $CHECK
-      stage: spec
+  - env: CHECK="check:symlinks check:git_ignore check:dot_underscore check:test_file
+      rubocop syntax lint metadata_lint"
+    stage: static
+  - env: PUPPET_GEM_VERSION="~> 5.0" CHECK=parallel_spec
+    rvm: 2.4.5
+    stage: spec
+  - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=parallel_spec
+    rvm: 2.5.3
+    stage: spec
+  - env: DEPLOY_TO_FORGE=yes
+    stage: deploy
+  - env: PUPPET_GEM_VERSION="~> 6.0" CHECK=integration_test
+    rvm: 2.5.3
+    script: travis_wait 40 bundle exec rake $CHECK
+    stage: spec
 branches:
   only:
-    - master
-    - /^v\d/
+  - master
+  - "/^v\\d/"
 notifications:
   email: false
 deploy:
   provider: puppetforge
   user: dodevops
   password:
-    secure: "oOMnNF5/e+WUnWy9G3opVbK+1fm1FaR0/vQ+2EAgbDHtcX+Kkh0yOdsVZhfD9SN1bCI8dktYNGsMdRm8GruW3O+lZ2bQFbGNbf/du8tIWAvAYe0b9892ertHu+ZMjoyAg0LdqDyFoZWKQgpCKco26t2dZ4JDvCpzt5N2bsdrfFyGpX2uBA1UgaH+iscUvfJPObi2f1EkzyW9avQcRbv4ej1LO9fhOCmflBLXmj5EO+ZKArnAop5mYsmdVMIuF2R1KZ7vQE0N3kva0cMpfrgBI2dmg2uJV/QRj7lD+7a40NklqyMEy8Op1IkNHLKV8eL6cfi8kyRoJSRYv6PjdMm6ij2KGfb0DJpytei1O7m4yMpXpkrm6wdiai2sMhHu0DK/hZJr3xBm7Y2RlMz38mFS2ytQLfe5ZlMK8lMisyxEj0ljT8cEFDHqaUnBqCMbYWwx19LssHtLN3WDT4vDpctiiUH6mO4j3MWjlS9iKZ57Yz5qVnjo2JplBV1X6FSCkSIOBWQxXWpnQCurh3oZUWKSIm8XE+QLiaoQr1TTGwe0Epxgml1FyoBq1tGSiXJEkaF4+cT8q2ICjxdSzVcBFkJy0GmlAOBK0IsLmnlxwcEBs4aVCgtJi7Q1/eV74iNsuHiXNOdzQ20Kh8x0ZTvfM7vYr7cOgQ/hTW0pbA09N6HXFzY="
+    secure: oOMnNF5/e+WUnWy9G3opVbK+1fm1FaR0/vQ+2EAgbDHtcX+Kkh0yOdsVZhfD9SN1bCI8dktYNGsMdRm8GruW3O+lZ2bQFbGNbf/du8tIWAvAYe0b9892ertHu+ZMjoyAg0LdqDyFoZWKQgpCKco26t2dZ4JDvCpzt5N2bsdrfFyGpX2uBA1UgaH+iscUvfJPObi2f1EkzyW9avQcRbv4ej1LO9fhOCmflBLXmj5EO+ZKArnAop5mYsmdVMIuF2R1KZ7vQE0N3kva0cMpfrgBI2dmg2uJV/QRj7lD+7a40NklqyMEy8Op1IkNHLKV8eL6cfi8kyRoJSRYv6PjdMm6ij2KGfb0DJpytei1O7m4yMpXpkrm6wdiai2sMhHu0DK/hZJr3xBm7Y2RlMz38mFS2ytQLfe5ZlMK8lMisyxEj0ljT8cEFDHqaUnBqCMbYWwx19LssHtLN3WDT4vDpctiiUH6mO4j3MWjlS9iKZ57Yz5qVnjo2JplBV1X6FSCkSIOBWQxXWpnQCurh3oZUWKSIm8XE+QLiaoQr1TTGwe0Epxgml1FyoBq1tGSiXJEkaF4+cT8q2ICjxdSzVcBFkJy0GmlAOBK0IsLmnlxwcEBs4aVCgtJi7Q1/eV74iNsuHiXNOdzQ20Kh8x0ZTvfM7vYr7cOgQ/hTW0pbA09N6HXFzY=
   on:
     tags: true
     all_branches: true
     condition: "$DEPLOY_TO_FORGE = yes"
+env:
+  global:
+    DOCKER_USERNAME=dodevopsdocker
+    secure: fH/ce9WPbfSNA/2w2IGSLB1r9SituIHXGHS0iFhFZlfJUfvfrW5PLg/AnZawC2+5cK6VR5IKeIvUhwidzC4X/3mmr9oWi56ec7r8XMy1sz3cmLVvUOwbsAoI2YKHvr5Nd3gtdaD4YaAEy6OL0wTpZt7gkzfxIRwncPDz+EwVtaViT1fhxFwa2Au7ukpWSiSLGin1u4RHEwYoDgUE50+4RTy0fWnzuATakLXBXfB4j4Gi1Trusx1rAjJVJMQw+v61YayrPz348LVmla76Enx46lM1n6MLepv5IYjBfWflQDfNLaPam8GiYkSsI/u68W0Zyz8N9mWnTROFeM/TsH9dfrGs0ohznyKCMvFCamM7lAXJENNHEGuU6iPK/FxBvGh+6hxmktYdKw9h0slH+e2SIeQLGvQb8BgFWPRg5vGmJVeVzYtLDVD2pkv43+ZwQ1fiuLwED3E6Px/ImDnJsW41qZwmCewua3wbjjpHsvDg8g9JgXwIvt6C3EJ/v/aXzUtKsEMC2hgG2D3f0jyfwdqosOhIK56BFmE55e9wLt2dR7EW+oprDjA3p7erFpkKfjwxycJEMwqYQgHvDd0TQT2TSPzhummiUoB/YZCtjcBBMCc6BPVpyt3R87n5QJnF0th7uI6dTmE6mo9TwkzyDhDWdG+PyiHEbQMWz3Yh2BkmOiU=

--- a/README.md
+++ b/README.md
@@ -11,4 +11,4 @@ Current features include:
 
 ## Usage
 
-See the reference page for details on the available classes. 
+See the REFERENCE page for details on the available classes. 

--- a/REFERENCE.md
+++ b/REFERENCE.md
@@ -36,23 +36,40 @@ class {
     gpg_url = 'https://my.repository.company.com/gpg',
     gpg_id = '6688A3782BBFE5A4',
     monitors = {
-        'mycheck': {
-          script_source: 'puppet:///my/script.sh'
-          arguments: [
+        'mycheck' => {
+          script_source => 'puppet:///my/script.sh'
+          arguments => [
             '--yellow=80',
             '--red=90',
             '--check-values=/etc/xymon/files/rootcheck.cfg
           ],
           sudo: {
-            'rootcheck': {
-              content: 'xymon ALL=(ALL) NOPASSWD: /usr/bin/rootcheck',
+            'rootcheck' => {
+              content => 'xymon ALL=(ALL) NOPASSWD: /usr/bin/rootcheck',
             }
           },
-          packages: {
-            'rootcheck': { ensure: 'latest' },
+          packages => {
+            'rootcheck' => { ensure => 'latest' },
           },
-          files: {
-            'rootcheck.cfg': 'puppet:///my/rootcheck.cfg',
+          files => {
+            'rootcheck.cfg' => {
+               source => 'puppet:///my/rootcheck.cfg',
+               mode => '0600',
+             },
+            'mysql_connection.mycfg => {
+               template => 'my/mysql_connection/mysql_connection.cfg.epp,
+               mode => '0600',
+               vars => {
+                 host => 'foo.bar.com',
+                 user => 'fancydbuser',
+                 password => 'fancypassword', # eyaml recommended here!
+               }
+            }
+          },
+          logrotate => {
+            path   => '/var/log/xymon/script.log',
+            size   => '20M',
+            rotate => 5,
           }
         }
     }
@@ -169,6 +186,28 @@ Default value: ``undef``
 Data type: `Optional[Hash]`
 
 A hash of tests to configure
+@option monitors :script_source A Puppet file source to the script for the monitor
+@option monitors :clientlaunch_config Path to the Xymon clientlaunch path.
+@option monitors :files_path Path to the a path for additional files.
+@option monitors :xymon_user Xymon user.
+@option monitors :xymon_group Xymon group.
+@option monitors :xymon_service Xymon service name.
+@option monitors :interval A valid Xymon client interval string when to run the script
+@option monitors :arguments A list of command line arguments to start the script with
+@option monitors :require_fqdn Require that the agent has the specified FQDN for the monitor to be installed
+@option monitors :files A hash of filenames as key and sources as values to add to the xymon files
+ @option files :source A Puppet file source for the additional file for the monitor
+ @option files :template A Puppet template for the additional file for the monitor
+ @option files :vars A hash of variables used in the template
+ @option files :mode file mode of the additional file for the monitor
+ @option files :owner owner of the additional file for the monitor
+ @option files :group group of the additional file for the monitor
+@option monitors :sudo A sudo::conf hash with sudo definitions the xymon user should be allowed to use
+@option monitors :packages A puppet package hash with packages that are required for the monitor to work
+@option monitors :logrotate A hash containing definitions to configure logfile rotation
+ @option logrotate :path path for the file to logrotate
+ @option logrotate :size file size threshold when to rotate (human readable format accepted)
+ @option logrotate :rotate how many times the log is rotated until it is deleted
 
 Default value: ``undef``
 
@@ -317,7 +356,6 @@ Sets up a xymon monitor
 
 The following parameters are available in the `xymon::client::monitor` defined type:
 
-* [`script_source`](#script_source)
 * [`clientlaunch_config`](#clientlaunch_config)
 * [`files_path`](#files_path)
 * [`xymon_user`](#xymon_user)
@@ -326,15 +364,13 @@ The following parameters are available in the `xymon::client::monitor` defined t
 * [`interval`](#interval)
 * [`arguments`](#arguments)
 * [`require_fqdn`](#require_fqdn)
+* [`script_source`](#script_source)
+* [`script_template`](#script_template)
+* [`script_vars`](#script_vars)
 * [`files`](#files)
 * [`sudo`](#sudo)
 * [`packages`](#packages)
-
-##### <a name="script_source"></a>`script_source`
-
-Data type: `String`
-
-A Puppet file source to the script for the monitor
+* [`logrotate`](#logrotate)
 
 ##### <a name="clientlaunch_config"></a>`clientlaunch_config`
 
@@ -390,11 +426,41 @@ Require that the agent has the specified FQDN for the monitor to be installed
 
 Default value: ``undef``
 
+##### <a name="script_source"></a>`script_source`
+
+Data type: `Optional[String]`
+
+A Puppet file source to the script for the monitor (mutually exclusive with script_template)
+
+Default value: ``undef``
+
+##### <a name="script_template"></a>`script_template`
+
+Data type: `Optional[String]`
+
+A Puppet file source to the script for the monitor (mutually exclusive with script_source)
+
+Default value: ``undef``
+
+##### <a name="script_vars"></a>`script_vars`
+
+Data type: `Optional[Hash]`
+
+A hash of variables for script_template (if used)
+
+Default value: ``undef``
+
 ##### <a name="files"></a>`files`
 
 Data type: `Optional[Hash]`
 
 A hash of filenames as key and sources as values to add to the xymon files
+@option files :source A Puppet file source for the additional file for the monitor (mutually exclusive with template)
+@option files :template A Puppet template for the additional file for the monitor (mutually exclusive with source)
+@option files :vars A hash of variables used in the template
+@option files :mode file mode of the additional file for the monitor
+@option files :owner owner of the additional file for the monitor
+@option files :group group of the additional file for the monitor
 
 Default value: ``undef``
 
@@ -411,6 +477,17 @@ Default value: ``undef``
 Data type: `Optional[Hash]`
 
 A puppet package hash with packages that are required for the monitor to work
+
+Default value: ``undef``
+
+##### <a name="logrotate"></a>`logrotate`
+
+Data type: `Optional[Hash]`
+
+A hash containing definitions to configure logfile rotation
+@option logrotate :path path for the file to logrotate
+@option logrotate :size file size threshold when to rotate (human readable format accepted)
+@option logrotate :rotate how many times the log is rotated until it is deleted
 
 Default value: ``undef``
 

--- a/metadata.json
+++ b/metadata.json
@@ -1,6 +1,6 @@
 {
   "name": "dodevops-xymon",
-  "version": "0.3.0",
+  "version": "0.4.0",
   "author": "dodevops",
   "summary": "Puppet module for managing Xymon",
   "license": "MIT",


### PR DESCRIPTION
In our environment some check scripts are using templates for the monitoring script. This PR adds the possibility to use that.

Same time i updated the documentation and added a docker login to travis checks for smoother PR checks