### PR TITLE
fix: Take care of clientlaunch.d include on Suse

### DIFF
--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,1 +1,0 @@
-xymon::client::include_clientlaunch_d: false

--- a/data/family/Debian.yaml
+++ b/data/family/Debian.yaml
@@ -1,0 +1,1 @@
+xymon::client::include_clientlaunch_d: false

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,1 +1,2 @@
 xymon::client::config_file: "/etc/sysconfig/xymon-client"
+xymon::client::include_clientlaunch_d: false

--- a/data/family/RedHat.yaml
+++ b/data/family/RedHat.yaml
@@ -1,2 +1,1 @@
 xymon::client::config_file: "/etc/sysconfig/xymon-client"
-xymon::client::include_clientlaunch_d: false

--- a/data/family/Suse.yaml
+++ b/data/family/Suse.yaml
@@ -1,0 +1,1 @@
+xymon::client::include_clientlaunch_d: true

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -8,8 +8,9 @@
 #   Manage the repository for package installation
 #
 # @param include_clientlaunch_d
-#   Ensure, that clientlaunch.d/*.cfg is included in clientlaunch.cfg - some xymon packages miss to do so.
-#   Will not remove any include value false!
+#   If set to true, it is ensured, that directory "clientlaunch.d" is included in clientlaunch.cfg - some xymon packages miss to do so.
+#   If set to false, clientlaunch.cfg will not be touched (an existing directory include statement will not be removed, but also not be
+#   added, if it is missing).
 #
 # @param config_file
 #   Path to the xymon-client configuration file
@@ -251,7 +252,7 @@ class xymon::client (
       path => "${xymon_config_dir}/clientlaunch.cfg",
       line => "directory ${actual_clientlaunch_config}",
     }
-    File[$actual_clientlaunch_config] -> File_line[include_clientlaunch_d] -> Service[$service_name]
+    File[$actual_clientlaunch_config] -> File_line['include_clientlaunch_d'] ~> Service[$service_name]
   }
 
   if ($monitors) {

--- a/manifests/client.pp
+++ b/manifests/client.pp
@@ -7,6 +7,10 @@
 # @param manage_repository
 #   Manage the repository for package installation
 #
+# @param include_clientlaunch_d
+#   Ensure, that clientlaunch.d/*.cfg is included in clientlaunch.cfg - some xymon packages miss to do so.
+#   Will not remove any include value false!
+#
 # @param config_file
 #   Path to the xymon-client configuration file
 #
@@ -138,6 +142,7 @@
 class xymon::client (
   String $xymon_server,
   Boolean $manage_repository            = true,
+  Boolean $include_clientlaunch_d       = false,
   String $config_file                   = '/etc/default/xymon-client',
   String $package                       = 'xymon-client',
   String $service_name                  = 'xymon-client',
@@ -239,6 +244,14 @@ class xymon::client (
   -> service {
     $service_name:
       ensure => 'running'
+  }
+
+  if ($include_clientlaunch_d) {
+    file_line { 'include_clientlaunch_d':
+      path => "${xymon_config_dir}/clientlaunch.cfg",
+      line => "directory ${actual_clientlaunch_config}",
+    }
+    File[$actual_clientlaunch_config] -> File_line[include_clientlaunch_d] -> Service[$service_name]
   }
 
   if ($monitors) {

--- a/spec/classes/client_spec.rb
+++ b/spec/classes/client_spec.rb
@@ -23,16 +23,19 @@ describe 'xymon::client' do
             is_expected.to contain_class('xymon::repository::apt')
             is_expected.to contain_apt__source('xymon')
             is_expected.to contain_apt__key('6688A3782BBFE5A4')
+            is_expected.not_to contain_file_line('include_clientlaunch_d')
           }
         when 'RedHat'
           it {
             is_expected.to contain_class('xymon::repository::yum')
             is_expected.to contain_yumrepo('xymon')
+            is_expected.not_to contain_file_line('include_clientlaunch_d')
           }
         when 'Suse'
           it {
             is_expected.to contain_class('xymon::repository::zypper')
             is_expected.to contain_zypprepo('xymon')
+            is_expected.to contain_file_line('include_clientlaunch_d')
           }
         else
           raise("Invalid os family #{os_facts[:os]['family']}")


### PR DESCRIPTION
The only real usable Suse package is this: https://software.opensuse.org/download.html?project=home%3Ajochenbecker&package=xymon-client
However it misses to include clientlaunch.d into clientlaunch.cfg, so configured monitors are not picked up.
This PR changes that, by including it for Suse and making it optional for other OS.